### PR TITLE
check for GNU v10.x Fortran and update FFLAGS

### DIFF
--- a/buildscripts/libs/build_fms.sh
+++ b/buildscripts/libs/build_fms.sh
@@ -35,9 +35,11 @@ else
 fi
 
 export FC=$MPI_FC
+[[ -n $FC && `$FC --version` =~ GNU\ Fortran.*\ 1[0-9]\.[0-9]+ ]] && FC_GFORTRAN_10=1
 export CC=$MPI_CC
 
 export FFLAGS+=" -fPIC -w"
+[[ -n $FC_GFORTRAN_10 ]] && export FFLAGS+=" -fallow-argument-mismatch"
 export CFLAGS+=" -fPIC -w"
 export FCFLAGS="$FFLAGS"
 


### PR DESCRIPTION
## Description

Update build script for FMS to accommodate GNU Fortran v10.x; need to add `-fallow-argument-mismatch`

This PR borrows the code idiom from [jedi-stack PR #168](https://github.com/JCSDA/jedi-stack/pull/168) to determine if the Fortran compiler specified for building is GNU Fortran v10.x.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes https://github.com/JCSDA/jedi-stack/issues/171

## Dependencies

No dependencies; related to [jedi-stack PR #160](https://github.com/JCSDA/jedi-stack/pull/160) `add FMS to the stack`

## Impact

No impact to other repositories or test data.

## Done

- [x] Build stack / install module as appropriate where GNU Fortran v10.x is available
  - [x] macOS: clang v11.0.3 and GNU 10.2.0, mpich-3.3.2 and openmpi-4.0.3
  - [x] Orion: GNU v10.2.0 compiler suite, openmpi-4.0.4

